### PR TITLE
Fix metrics summary popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -757,7 +757,7 @@
                                     // Asumiendo datosRaw no es 1d, recalcular con fetch
                                     fetch(\`https://fapi.binance.com/fapi/v1/klines?symbol=${par}&interval=1d&limit=14\`)
                                     .then(res => res.json())
-                                    .then(datos14d => {
+                                    .then(datos14 => {
                                         const closes14 = datos14.map(vela => parseFloat(vela[4]));
                                         const highs14 = datos14.map(vela => parseFloat(vela[2]));
                                         const lows14 = datos14.map(vela => parseFloat(vela[3]));
@@ -793,7 +793,7 @@
                             });
                             // Calcular inicial con 14
                             mostrarResumen(14);
-                        </script>
+                        <\/script>
                     </body>
                     </html>
                 `;


### PR DESCRIPTION
## Summary
- escape closing script tag in summary popup
- fix variable name when fetching historical candles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c2d607750832dac0affa97a401127