### PR TITLE
Hide table when metrics viewed

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,6 +253,7 @@
             const tituloReporte = document.getElementById('tituloReporte');
             const progresoPorcentual = document.getElementById('progresoPorcentual');
             const totalPares = document.getElementById('totalPares');
+            const resultadosDiv = document.getElementById('resultados');
             const buscarMaximosButton = document.getElementById('buscarMaximos');
             const exportarCSVButton = document.getElementById('exportarCSV');
             const calcularResumenButton = document.getElementById('calcularResumen');
@@ -753,6 +754,11 @@
                     alert('No hay datos de velas para analizar.');
                     return;
                 }
+
+                // Ocultar tabla y progresos
+                resultadosDiv.style.display = 'none';
+
+                // Mostrar resumen
                 resumenDiv.innerHTML = `
                     <div id="resumen"></div>
                     <div style="margin-top:10px;">


### PR DESCRIPTION
## Summary
- toggle metrics display by hiding candlestick table

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cfb58fbac832d9eba3680bb817405