### PR TITLE
Reset metrics summary when submitting new query

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,6 +261,7 @@
             const exportarCSVButton = document.getElementById('exportarCSV');
             const calcularResumenButton = document.getElementById('calcularResumen');
             const toggleTablaButton = document.getElementById('toggleTabla');
+            const resumenDiv = document.getElementById('resumenContainer');
             let spotPares = [];
             let futurosPares = [];
             let sortOrder = 1;
@@ -311,6 +312,12 @@
                 const nuevoCodigoUnico = generarCodigoUnico();
                 currentDateTime = new Date().toISOString().replace('T', ' ').slice(0, 19);
                 document.getElementById('currentDateTime').textContent = currentDateTime;
+                // Reset visual state
+                resumenDiv.style.display = 'none';
+                resumenDiv.innerHTML = '';
+                resultadosDiv.style.display = 'block';
+                toggleTablaButton.style.display = 'none';
+                toggleTablaButton.textContent = 'Ver tabla de velas';
                 mostrarCargando();
                 dataTable.innerHTML = '';
                 isMaximosMode = false;
@@ -745,7 +752,6 @@
                 `;
                 document.getElementById('resumen').innerHTML = html;
             }
-            const resumenDiv = document.getElementById('resumenContainer');
             calcularResumenButton.addEventListener('click', () => {
                 if (datosRaw.length === 0) {
                     alert('No hay datos de velas para analizar.');


### PR DESCRIPTION
## Summary
- Ensure metrics summary is hidden when a new query is submitted
- Reset table visibility and toggle button on each form submission

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e9a83e218832db16d3a2d472a324d