### PR TITLE
Reordena `#mainPanel` y mejora espaciado CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,15 +158,19 @@
             min-height: 0;
             overflow: hidden;
             margin-top: 8px;
+            gap: 12px;
+            padding-bottom: 8px;
         }
         #resumenContainer {
             background: #f0f8f0;
             border: 2px solid #4caf50;
             border-radius: 8px;
             padding: 18px;
-            margin-bottom: 12px;
             box-shadow: 0 4px 15px rgba(76, 175, 80, 0.2);
             flex-shrink: 0;
+        }
+        #resultados {
+            padding-bottom: 4px;
         }
     </style>
 </head>
@@ -236,6 +240,9 @@
         </fieldset>
     </form>
     <div id="mainPanel">
+        <div id="resumenContainer" class="summary-panel">
+            <div id="resumen"></div>
+        </div>
         <div id="resultados">
             <p id="progresoPorcentual">0%</p>
             <p id="totalPares">Total de pares procesados: 0, Total de pares válidos: 0</p>
@@ -256,9 +263,6 @@
                 </thead>
                 <tbody></tbody>
             </table>
-        </div>
-        <div id="resumenContainer" class="summary-panel">
-            <div id="resumen"></div>
         </div>
     </div>
     <script>


### PR DESCRIPTION
### Motivation
- Alinear la estructura del HTML para que el panel resumen (`#resumenContainer`) se renderice antes de los resultados (`#resultados`) según el orden solicitado y mejorar la experiencia visual.
- Robustecer el layout frente a scroll y cambios de contenido aplicando ajustes de espaciado en CSS para evitar solapamientos y márgenes frágiles.

### Description
- Movido el bloque HTML de `#resumenContainer` para que aparezca antes de `#resultados` dentro de `#mainPanel` en `index.html`.
- Añadido `gap: 12px` y `padding-bottom: 8px` a `#mainPanel` para mejorar separación y consistencia del layout.
- Eliminado el `margin-bottom` fijo en `#resumenContainer` y añadido `padding-bottom: 4px` a `#resultados` para un espaciado más estable al hacer scroll.
- No se modificó la lógica JavaScript; los cambios son puramente estructurales y de estilo.

### Testing
- No se ejecutaron pruebas unitarias automatizadas sobre la aplicación; no se añadieron tests nuevos.
- Validación automatizada de los cambios de archivo mediante un script de reemplazo en `python`, y verificación del contenido con listado de archivos (`rg --files`) y previsualización (`nl`), y todos los comandos ejecutados retornaron éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa94be5f60832da18842dd8217e444)