### PR TITLE
Agregar sección de análisis con selector Monte Carlo/Ramsey

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,17 @@
         th:nth-child(7), td:nth-child(7) { width: 10%; }
         th:nth-child(8), td:nth-child(8) { width: 10%; }
         th:nth-child(9), td:nth-child(9) { width: 10%; }
+        /* Análisis */
+        #analysisGroup {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+        #analysisLabel {
+            font-weight: 600;
+            color: #333;
+            white-space: nowrap;
+        }
         #cargandoDatos {
             font-weight: bold;
             color: red;
@@ -82,6 +93,7 @@
         }
         fieldset.actions {
             display: flex;
+            flex-wrap: wrap;
             gap: 10px;
             align-items: center;
         }
@@ -235,7 +247,14 @@
             <button type="submit">Consultar</button>
             <button type="button" id="buscarMaximos" style="display:none;">Buscar Pares en Máximos</button>
             <button type="button" id="exportarCSV">Exportar CSV</button>
-            <button type="button" id="calcularResumen" style="display:none;">Simulación Monte Carlo</button>
+            <div id="analysisGroup" style="display:none;">
+                <label for="analysisSelect" id="analysisLabel">Análisis:</label>
+                <select id="analysisSelect">
+                    <option value="monteCarlo">Simulación Monte Carlo</option>
+                    <option value="ramsey">Detección Ramsey</option>
+                </select>
+                <button type="button" id="ejecutarAnalisis">Ejecutar análisis</button>
+            </div>
             <button type="button" id="toggleTabla" style="display:none;">Ver tabla de velas</button>
         </fieldset>
     </form>
@@ -323,7 +342,9 @@
             const resultadosDiv = document.getElementById('resultados');
             const buscarMaximosButton = document.getElementById('buscarMaximos');
             const exportarCSVButton = document.getElementById('exportarCSV');
-            const calcularResumenButton = document.getElementById('calcularResumen');
+            const analysisGroup = document.getElementById('analysisGroup');
+            const analysisSelect = document.getElementById('analysisSelect');
+            const ejecutarAnalisisBtn = document.getElementById('ejecutarAnalisis');
             const toggleTablaButton = document.getElementById('toggleTabla');
             const resumenDiv = document.getElementById('resumenContainer');
             let spotPares = [];
@@ -425,6 +446,9 @@
                 toggleTablaButton.style.display = 'none';
                 toggleTablaButton.textContent = 'Ver tabla de velas';
             }
+            function actualizarVisibilidadAnalisis(action) {
+                analysisGroup.style.display = action === 'candles' ? 'inline-flex' : 'none';
+            }
             function alternarTablaSimulacion() {
                 const tablaOculta = resultadosDiv.style.display === 'none';
                 if (tablaOculta) {
@@ -461,7 +485,7 @@
                     procesarDatos(datos, action, par);
                     actualizarTitulo(tipoReporte, par, intervalo, nuevoCodigoUnico, action, marketSelect.value);
                     ocultarCargando();
-                    calcularResumenButton.style.display = action === 'candles' ? 'inline-block' : 'none';
+                    actualizarVisibilidadAnalisis(action);
                     toggleTablaButton.style.display = 'none';
                     resultadosDiv.style.display = 'flex';
                 } catch (error) {
@@ -703,6 +727,7 @@
                 actualizarListaPares();
                 filtroInput.dispatchEvent(new Event('input'));
                 buscarMaximosButton.style.display = marketSelect.value === 'futures' && actionSelect.value === 'marketData' ? 'inline-block' : 'none';
+                actualizarVisibilidadAnalisis(actionSelect.value);
             });
             actionSelect.addEventListener('change', () => {
                 intervalContainer.style.display = actionSelect.value === 'candles' ? 'inline-block' : 'none';
@@ -719,6 +744,7 @@
                     errorMessage.style.display = 'none';
                 }
                 buscarMaximosButton.style.display = marketSelect.value === 'futures' && actionSelect.value === 'marketData' ? 'inline-block' : 'none';
+                actualizarVisibilidadAnalisis(actionSelect.value);
             });
             actionSelect.dispatchEvent(new Event('change'));
             buscarMaximosButton.addEventListener('click', () => {
@@ -988,7 +1014,9 @@
 
                 return {S0,promedio,subida,bajada,ic95:[p2_5,p97_5],var95,horizonteHoras};
             }
-            calcularResumenButton.addEventListener('click', () => {
+            ejecutarAnalisisBtn.addEventListener('click', () => {
+                const tipo = analysisSelect.value;
+                if (tipo === 'monteCarlo') {
                 if (datosRaw.length === 0) {
                     alert('No hay datos de velas para analizar.');
                     return;
@@ -1077,6 +1105,9 @@
                     ventana.document.close();
                     ventana.print();
                 });
+                } else if (tipo === 'ramsey') {
+                    alert('🔧 Detección Ramsey - En desarrollo.\n\nEsta funcionalidad se implementará próximamente.');
+                }
             });
 
             toggleTablaButton.addEventListener('click', alternarTablaSimulacion);


### PR DESCRIPTION
### Motivation
- Preparar la interfaz para nuevas funcionalidades de análisis sobre velas manteniendo la simulación Monte Carlo existente.
- Permitir seleccionar distintos tipos de análisis desde el formulario de `Acciones` en lugar de un único botón fijo.
- Dejar un punto de extensión para implementar futuras detecciones (p. ej. Ramsey) sin alterar la lógica de simulación actual.

### Description
- Reemplacé el botón `calcularResumen` por un nuevo bloque HTML `#analysisGroup` que incluye el selector `#analysisSelect` y el botón `#ejecutarAnalisis` para escoger entre `monteCarlo` y `ramsey`.
- Añadí estilos CSS para `#analysisGroup` y `#analysisLabel` y ajusté `fieldset.actions` a `flex-wrap` para mejor adaptación responsiva.
- En JavaScript añadí referencias a `analysisGroup`, `analysisSelect` y `ejecutarAnalisisBtn`, implementé `actualizarVisibilidadAnalisis(action)` para mostrar el bloque solo cuando la acción es `candles`, y actualicé los listeners de `submit`, `marketSelect` y `actionSelect` para sincronizar visibilidad.
- Reemplacé el listener anterior de la simulación por un dispatcher en `ejecutarAnalisisBtn` que ejecuta la lógica de Monte Carlo cuando `analysisSelect` es `monteCarlo` y muestra un `alert` de placeholder para `ramsey`.

### Testing
- Ejecuté `git diff --check` y no reportó errores.
- Verifiqué el estado con `git status --short` y realicé un `git commit` exitoso con el mensaje `Agregar sección de análisis con selector Monte Carlo/Ramsey`.
- Se generó la descripción del PR mediante la herramienta interna (acción `make_pr`) y la operación finalizó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9857ff1c832da1e4c770196c72bc)