### PR TITLE
Conecta la detección Ramsey con cálculo y visualización

### DIFF
--- a/index.html
+++ b/index.html
@@ -1264,7 +1264,46 @@
                     ventana.print();
                 });
                 } else if (tipo === 'ramsey') {
-                    alert('🔧 Detección Ramsey - En desarrollo.\n\nEsta funcionalidad se implementará próximamente.');
+                    if (datosRaw.length === 0) {
+                        alert('No hay datos de velas para analizar.');
+                        return;
+                    }
+
+                    // Mantener la misma ventana de análisis usada por el sistema.
+                    // Si ya tenés lookback dinámico de 24 hs, reemplazar LOOKBACK_SIZE por esa función.
+                    const LOOKBACK_SIZE = 480;
+                    const datosParaCalculo = datosRaw.slice(-LOOKBACK_SIZE);
+
+                    if (datosParaCalculo.length < 20) {
+                        alert('Se requieren al menos 20 velas para la detección Ramsey.');
+                        return;
+                    }
+
+                    activarModoSimulacion();
+
+                    const windowSize = 10;
+
+                    const indicador = calcularIndicadorRamsey(datosParaCalculo, windowSize);
+                    const cruces = detectarCrucesRamsey(indicador);
+                    const estructuras = convertirCrucesRamseyAEstructuras(cruces);
+
+                    aplicarResaltadosRamsey(estructuras, datosParaCalculo.length);
+
+                    resumenDiv.innerHTML = '<div id="resumen" style="padding:30px;font-family:monospace;"></div>';
+                    resumenDiv.classList.add('show');
+
+                    document.getElementById('resumen').innerHTML = generarResumenRamseyHTML({
+                        currentTimeframe,
+                        lookbackLength: datosParaCalculo.length,
+                        windowSize,
+                        indicador,
+                        estructuras
+                    });
+
+                    document.body.scrollTop = 0;
+                    document.documentElement.scrollTop = 0;
+
+                    return;
                 }
             });
 


### PR DESCRIPTION
### Motivation
- Sustituir el placeholder de `ramsey` que mostraba un alert de “en desarrollo” por un flujo funcional que ejecute el cálculo y muestre los resultados en la UI.
- Mantener la coherencia con la capa visual ya implementada y permitir reemplazo futuro por un `lookback` dinámico de 24 horas.
- Evitar cambios en la sección de Monte Carlo y limitar la modificación al bloque `else if (tipo === 'ramsey')`.

### Description
- Reemplacé el bloque de `ramsey` para validar que `datosRaw` no esté vacío y cortar las últimas velas usando `const LOOKBACK_SIZE = 480;` y `datosRaw.slice(-LOOKBACK_SIZE)`.
- Añadí una validación de mínimo de 20 velas y la activación de simulación con `activarModoSimulacion()` antes de ejecutar el pipeline Ramsey.
- Ejecuté el pipeline completo llamando a `calcularIndicadorRamsey`, `detectarCrucesRamsey`, `convertirCrucesRamseyAEstructuras` y `aplicarResaltadosRamsey`, y rendericé el resumen con `generarResumenRamseyHTML(...)`.
- Dejé el comentario para reemplazar `LOOKBACK_SIZE` por cálculo dinámico de 24 horas si ya existe esa funcionalidad en el proyecto.

### Testing
- Ejecuté `rg -n "Detección Ramsey|tipo === 'ramsey'" index.html` para localizar el bloque modificado y la búsqueda devolvió las líneas esperadas (exitó exitosa).
- Visualicé las líneas modificadas con `nl -ba index.html | sed -n '1256,1325p'` para confirmar la inserción del nuevo bloque (salida mostrada correctamente).
- Realicé `git add index.html` y `git commit -m "Conecta la detección Ramsey con cálculo y visualización"` y el commit se efectuó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9e619cb4832daf26c2c8b6799046)