### PR TITLE
Corregir mapeo de filas Ramsey cuando se analiza un lookback parcial

### DIFF
--- a/index.html
+++ b/index.html
@@ -1098,14 +1098,15 @@
                 });
             }
 
-            function aplicarResaltadosRamsey(estructuras, totalDatos) {
+            function aplicarResaltadosRamsey(estructuras, totalDatos, offset = 0) {
                 const tbody = document.querySelector('#dataTable tbody');
                 if (!tbody) return;
 
                 limpiarResaltadosRamsey();
 
                 estructuras.forEach(est => {
-                    const filaIndex = totalDatos - 1 - est.index;
+                    const indexGlobal = offset + est.index;
+                    const filaIndex = totalDatos - 1 - indexGlobal;
 
                     if (tbody.rows[filaIndex]) {
                         tbody.rows[filaIndex].classList.add(est.clase, 'ramsey-mark');
@@ -1414,8 +1415,9 @@
                     const indicador = calcularIndicadorRamsey(datosParaCalculo, windowSize);
                     const cruces = detectarCrucesRamsey(indicador);
                     const estructuras = convertirCrucesRamseyAEstructuras(cruces);
+                    const offset = datosRaw.length - datosParaCalculo.length;
 
-                    aplicarResaltadosRamsey(estructuras, datosParaCalculo.length);
+                    aplicarResaltadosRamsey(estructuras, datosRaw.length, offset);
 
                     resumenDiv.innerHTML = '<div id="resumen" style="padding:30px;font-family:monospace;"></div>';
                     resumenDiv.classList.add('show');


### PR DESCRIPTION
### Motivation
- El resaltado de cruces Ramsey podía quedar desplazado cuando se ejecuta sobre una ventana parcial (`datosRaw.slice(-LOOKBACK_SIZE)`) porque se calculaba `filaIndex` respecto a la longitud del lookback en lugar de la tabla completa. 
- Mantengo `LOOKBACK_SIZE = 480` sin cambiar en este PR para limitar el alcance a la corrección del mapeo.

### Description
- Cambié la firma de `aplicarResaltadosRamsey` a `aplicarResaltadosRamsey(estructuras, totalDatos, offset = 0)` y ahora calcula `indexGlobal = offset + est.index` seguido de `filaIndex = totalDatos - 1 - indexGlobal` para mapear a la tabla global. 
- En el flujo de ejecución de Ramsey se añadió `const offset = datosRaw.length - datosParaCalculo.length;` y la llamada pasó a `aplicarResaltadosRamsey(estructuras, datosRaw.length, offset)` para alinear índices locales con la tabla completa.

### Testing
- Verifiqué la presencia y uso actualizado con `rg "aplicarResaltadosRamsey\(" -n /workspace/velasCripto/index.html` y confirmé las sustituciones (éxito). 
- Confirmé el cambio mediante `git` commit y revisé el `diff` para asegurar que las líneas modificadas coinciden con lo esperado (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9f8a60dc832da30014d22341f04f)