### PR TITLE
Ajusta listener principal y estilo del resumen Ramsey

### DIFF
--- a/index.html
+++ b/index.html
@@ -1301,11 +1301,11 @@
                 return cruces;
             }
 
-            // ==================== LISTENER DE ANÁLISIS ====================
+            // ==================== LISTENER PRINCIPAL DE ANÁLISIS ====================
             ejecutarAnalisisBtn.addEventListener('click', () => {
                 const tipo = analysisSelect.value;
 
-                // Limpiar resaltados previos
+                // Limpiar resaltados previos de Ramsey
                 limpiarResaltadosRamsey();
 
                 if (tipo === 'monteCarlo') {
@@ -1416,7 +1416,7 @@
 
                 aplicarResaltadosRamsey(estructuras, datosParaCalculo.length);
 
-                resumenDiv.innerHTML = '<div id="resumen" style="padding:30px;font-family:monospace;"></div>';
+                resumenDiv.innerHTML = '<div id="resumen" style="padding:20px;"></div>';
                 resumenDiv.classList.add('show');
 
                 document.getElementById('resumen').innerHTML = generarResumenRamseyHTML({


### PR DESCRIPTION
### Motivation
- Aplicar las correcciones puntuales solicitadas: unificar el encabezado del listener principal, dejar `ejecutarMonteCarlo()` limpio y mejorar la presentación del resumen de la detección Ramsey.

### Description
- Se renombró el comentario del bloque listener a `// ==================== LISTENER PRINCIPAL DE ANÁLISIS ====================`, se cambió el comentario interno a `// Limpiar resaltados previos de Ramsey` y se ajustó el `resumenDiv.innerHTML` dentro de `ejecutarDeteccionRamsey()` para usar `padding:20px;`, sin modificar la lógica de enrutado entre `ejecutarMonteCarlo()` y `ejecutarDeteccionRamsey()`; archivo modificado: `index.html`.

### Testing
- Se ejecutaron búsquedas y comprobaciones de cambios con `rg -n "ejecutarAnalisisBtn.addEventListener|function ejecutarMonteCarlo|function ejecutarDeteccionRamsey" -S .`, `git diff -- index.html` y se confirmó el commit con `git commit -m "Ajusta listener principal y estilo del resumen Ramsey"`, todos completados con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa1e25d98832d9b4835060c33d1cb)