### PR TITLE
Fix Ramsey highlight alignment when using partial analysis window

### DIFF
--- a/index.html
+++ b/index.html
@@ -1413,8 +1413,9 @@
                 const indicador = calcularIndicadorRamsey(datosParaCalculo, windowSize);
                 const cruces = detectarCrucesRamsey(indicador);
                 const estructuras = convertirCrucesRamseyAEstructuras(cruces);
+                const offsetGlobal = datosRaw.length - datosParaCalculo.length;
 
-                aplicarResaltadosRamsey(estructuras, datosParaCalculo.length);
+                aplicarResaltadosRamsey(estructuras, datosRaw.length, offsetGlobal);
 
                 resumenDiv.innerHTML = '<div id="resumen" style="padding:20px;"></div>';
                 resumenDiv.classList.add('show');


### PR DESCRIPTION
### Motivation
- Ensure Ramsey-detected crossings computed on a sliced lookback are mapped to the correct rows of the full, inverted table so highlights are not offset when `datosRaw` is larger than the analyzed window.

### Description
- Compute `offsetGlobal = datosRaw.length - datosParaCalculo.length` and call `aplicarResaltadosRamsey(estructuras, datosRaw.length, offsetGlobal)` instead of passing the slice length so detected indices are translated to global table rows.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa2c0a848832da1cc21c17f79e3d1)